### PR TITLE
Add conversion support from/to lat/lon/alt and x/y/z 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ Read/Write quantized-mesh tiles
 #### Get the latest traceback
 
     %tb
+
+
+## Styling
+
+#### Check styling
+
+    venv/bin/flakes8 --ignore=E501 {yourFile}.py
+
+#### Fix styling (only pep8 errors)
+
+    venv/bin/autopep8 -v -i -a --ignore=E501 {yourFile}.py

--- a/README.md
+++ b/README.md
@@ -2,4 +2,19 @@
 Read/Write quantized-mesh tiles
 
 ## Getting started
-./setup.sh
+
+    ./setup.sh
+
+## Interactive programming
+
+    source venv/bin/activate
+    ipython
+    run {yourScript}.py
+
+#### Enter debug mode
+
+    %debug
+
+#### Get the latest traceback
+
+    %tb

--- a/forge/lib/llh_ecef.py
+++ b/forge/lib/llh_ecef.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import math
+
+# Stolen from https://github.com/bistromath/gr-air-modes/blob/master/python/mlat.py
+# WGS84 reference ellipsoid constants
+# http://en.wikipedia.org/wiki/Geodetic_datum#Conversion_calculations
+# http://en.wikipedia.org/wiki/File%3aECEF.png
+wgs84_a = 6378137.0               # Semi-major axis
+wgs84_b = 6356752.314245          # Semi-minor axis
+wgs84_e2 = 0.0066943799901975848  # First eccentricity squared
+wgs84_a2 = wgs84_a ** 2           # To speed things up a bit
+wgs84_b2 = wgs84_b ** 2
+
+
+def LLH2ECEF(lat, lon, alt):
+    lat *= (math.pi / 180.0)
+    lon *= (math.pi / 180.0)
+
+    n = lambda x: wgs84_a / math.sqrt(1 - wgs84_e2 * (math.sin(x) ** 2))
+
+    x = (n(lat) + alt) * math.cos(lat) * math.cos(lon)
+    y = (n(lat) + alt) * math.cos(lat) * math.sin(lon)
+    z = (n(lat) * (1 - wgs84_e2) + alt) * math.sin(lat)
+
+    return [x, y, z]
+
+# alt is in meters
+
+
+def ECEF2LLH(x, y, z):
+    ep = math.sqrt((wgs84_a2 - wgs84_b2) / wgs84_b2)
+    p = math.sqrt(x ** 2 + y ** 2)
+    th = math.atan2(wgs84_a * z, wgs84_b * p)
+    lon = math.atan2(y, x)
+    lat = math.atan2(z + ep ** 2 * wgs84_b * math.sin(th) ** 3, p - wgs84_e2 * wgs84_a * math.cos(th) ** 3)
+    N = wgs84_a / math.sqrt(1 - wgs84_e2 * math.sin(lat) ** 2)
+    alt = p / math.cos(lat) - N
+
+    lon *= (180. / math.pi)
+    lat *= (180. / math.pi)
+
+    return [lat, lon, alt]

--- a/forge/tests/test_llh_ecef.py
+++ b/forge/tests/test_llh_ecef.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from forge.lib.llh_ecef import LLH2ECEF, ECEF2LLH
+
+# Conversion reference
+# http://www.oc.nps.edu/oc2902w/coord/llhxyz.htm
+class TestLLFECEF(unittest.TestCase):
+
+    def testLLFToECEF(self):
+        (lat, lon, alt) = (0, 0, 0)
+        (x, y, z) = LLH2ECEF(lat, lon, alt)
+        self.failUnless(x == 6378137.0)
+        self.failUnless(y == 0.0)
+        self.failUnless(z == 0.0)
+
+        # Swiss like lat/lon/alt
+        (lat, lon, alt) = (8.23, 4.03, 707)
+        (x, y, z) = LLH2ECEF(lat, lon, alt)
+        self.failUnless(round(x) == 6297973.0)
+        self.failUnless(round(y) == 443711.0)
+        self.failUnless(round(z) == 907064.0)
+
+    def testECEF2LLH(self):
+        (x, y, z) = (0, 0, 6358000)
+        (lat, lon, alt) = ECEF2LLH(x, y, z)
+        self.failUnless(lat == 90.0)
+        self.failUnless(lon == 0.0)
+        self.failUnless(round(z) == 6358000.0)
+
+        # Swiss like x/y/z
+        (x, y, z) = (6297973, 443711, 907064)
+        (lat, lon, alt) = ECEF2LLH(x, y, z)
+        self.failUnless(round(lat, 2) == 8.23)
+        self.failUnless(round(lon, 2) == 4.03)
+        self.failUnless(round(alt) == 707.0) 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@
 
 from setuptools import setup
 
+requires = [
+        'ipython',
+    ]
+
 setup(name='3d-forge',
       version='0.0',
       description='QMesh reader/writer',
@@ -10,4 +14,6 @@ setup(name='3d-forge',
       author_email='',
       license='MIT',
       packages=['forge'],
-      zip_safe=False)
+      zip_safe=False,
+      install_requires=requires,
+      )

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 
 requires = [
         'ipython',
+        'nose',
     ]
 
 setup(name='3d-forge',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 from setuptools import setup
 
 requires = [
+        'autopep8',
+        'flake8',
         'ipython',
         'nose',
     ]


### PR DESCRIPTION
As stated in https://cesiumjs.org/data-and-assets/terrain/formats/quantized-mesh-1.0.html
quantized-mesh-1.0 terrain format requires Earth-centered Fixed coordinates (or ECEF)

TINs produce by Topography are in lat/lon/alt which means that we need to convert it.

This PR introduces the functions to perform such transforms.
Do you think we need geoid corrected transforms?
The ellipsoid/geoid separation ranges from a value of +100 meters to -100 meters.

We would then need a reference to the geoid which is done here:
https://github.com/bistromath/gr-air-modes/blob/master/python/mlat.py

I don't think this is needed as Cesium must probably not make this kinds of considerations assume the earth is a perfect ellispoid.

Other references can be found directly in the code.

I also added some lib for testing and linting.
