### PR TITLE
Use system site package for gdal

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-virtualenv venv
+virtualenv --system-site-packages venv
 source venv/bin/activate
 python setup.py develop


### PR DESCRIPTION
This is to enable the usage of the local gdal install if not found in the eggs.