### PR TITLE
Adding 3d-testapp (private) as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 *.dbf
 *.prj
 *.shp
+*.mako

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3d-testapp"]
+	path = 3d-testapp
+	url = https://github.com/geoadmin/3d-testapp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VENV = venv
 PYTHON_CMD = $(VENV)/bin/python
 PORT ?= 9025
 PYTHON_FILES := $(shell find forge/ -name '*.py')
+USERNAME := $(shell whoami)
 
 .PHONY: help
 help:
@@ -23,12 +24,15 @@ help:
 	@echo
 
 .PHONY: all
-all: install lint
+all: install apache/testapp.conf lint
 
 .PHONY: install
 install:
 	virtualenv $(VENV) --system-site-packages
 	$(PYTHON_CMD) setup.py develop
+
+apache/testapp.conf: apache/testapp.conf.mako
+	$(VENV)/bin/mako-render --var "user=$(USERNAME)" --var "directory=$(CURDIR)" $< > $@
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # 3d-forge
 Read/Write quantized-mesh tiles
 
+To clone use the --recursive option to get all submodules.
+`git clone --recursive https://github.com/geoadmin/3d-forge`
+
 ## Getting started
 
     make all

--- a/apache/testapp.conf
+++ b/apache/testapp.conf
@@ -1,0 +1,8 @@
+AliasMatch ^/ltjeg/3dtest(.*)$ /home/ltjeg/3d-forge/3d-testapp/$1
+<Directory /home/ltjeg/3d-forge/3d-testapp/>
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+</Directory>
+
+

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ requires = [
         'flake8',
         'ipython',
         'nose',
+        'mako',
     ]
 
 setup(name='3d-forge',


### PR DESCRIPTION
This adds the private 3d-testapp git repository as submodule to 3d-forge. I've got the application to work exactly once using current simple https server. Mostly, I had ERR_CONTENT_LENGTH_MISMATCH on some files. Couldn't find a solution yet. Also, did not adapt the testing application yet.

Use `git clone --recursive https://github.com/geoadmin/3d-forge`  to clone the repo with the submodules.

**3d-testapp should remain private**. It contains the source code as send by Guillaume, which we can/will adapt according to our needs.

Working with submodules as a little cumbersome in git, here is the reference: http://git-scm.com/book/en/v2/Git-Tools-Submodules