### PR TITLE
Terrain Format: Generalize and optimize shapefiles creation

### DIFF
--- a/forge/scripts/create_shptoterrain.py
+++ b/forge/scripts/create_shptoterrain.py
@@ -21,7 +21,8 @@ terrainTopo = TerrainTopology(features)
 terrainTopo.create()
 terrainFormat = TerrainTile()
 terrainFormat.fromTerrainTopology(terrainTopo)
-terrainFormat._updateCoords()
-print terrainFormat
-
 terrainFormat.toFile(filePathTarget)
+
+# Display SwissCoordinates
+terrainFormat.computeVerticesCoordinates(epsg=21781)
+print terrainFormat

--- a/forge/scripts/create_testdata.py
+++ b/forge/scripts/create_testdata.py
@@ -12,4 +12,7 @@ filePathTarget = '%s/%s%s' % (directory, basename, extension)
 ter = TerrainTile()
 ter.fromFile(filePathSource, 7.80938, 7.81773, 46.30261, 46.30799)
 ter.toShapefile(filePathTarget)
+
+# In order to display swiss coordinates
+ter.computeVerticesCoordinates(epsg=21781)
 print ter

--- a/forge/scripts/terrain_reader.py
+++ b/forge/scripts/terrain_reader.py
@@ -6,5 +6,5 @@ ter = TerrainTile()
 # ter.fromFile('forge/data/quantized-mesh/0.terrain')
 ter.fromFile('forge/data/quantized-mesh/raron.flat.1.terrain', 7.80938, 7.81773, 46.30261, 46.30799)
 # ter.fromFile('forge/data/quantized-mesh/goms.mountains.1.terrain')
-ter._updateCoords()
+ter.computeVerticesCoordinates(epsg=21781)
 print ter


### PR DESCRIPTION
Before we were relying on `_updateCoords` to both write a shapefile and display vertices in Swiss coordinate system (only).

When calling toShapefile we would perform a transformation to swiss coordinates that was actually not needed.

I generalized this concept so that this doesn't occur unless we specify a custom `EPSG` in which case the generated shapefile is generated in the specified projection.