### PR TITLE
Add tests on bounding sphere

### DIFF
--- a/forge/tests/test_bounding_sphere.py
+++ b/forge/tests/test_bounding_sphere.py
@@ -2,7 +2,9 @@
 
 import unittest
 from decimal import Decimal
+from forge.models.terrain import TerrainTile
 from forge.lib.bounding_sphere import BoundingSphere
+from forge.lib.llh_ecef import LLH2ECEF
 
 
 class TestBoundingSphere(unittest.TestCase):
@@ -36,3 +38,16 @@ class TestBoundingSphere(unittest.TestCase):
         pointOutside = [1000.0, 1000.0, 1000.0]
         distance = sphere.distance(sphere.center, pointOutside)
         self.failUnless(distance > sphere.radius)
+
+    def testBoundingSpherePrecision(self):
+        tilePath = 'forge/data/quantized-mesh/raron.flat.1.terrain'
+        ter = TerrainTile()
+        ter.fromFile(tilePath, 7.80938, 7.81773, 46.30261, 46.30799)
+        coords = ter.getVerticesCoordinates()
+        llh2ecef = lambda x: LLH2ECEF(x[0], x[1], x[2])
+        coords = map(llh2ecef, coords)
+        sphere = BoundingSphere()
+        sphere.fromPoints(coords)
+        for coord in coords:
+            distance = sphere.distance(sphere.center, coord)
+            self.failUnless(distance <= sphere.radius)


### PR DESCRIPTION
@gjn That's where I am little puzzeled.

When reading the a tile coming from the POC, I get a radius of 92.8792837369.
What I am testing here is :

1. Extract the vertices
2. Convert the vertices from lon/lat/h to x/y/z
3. Create the bounding sphere 

I get a radius of 20.9583953749, so smaller than the radius red in the tile, but then all the points are contained within the sphere...

So I guess the error might now come only from:

1. Decoding (seems unlikely)
2. The conversion function to ECEF? (again doubled check and seems to work everywhere else)
3. An error while generating the tiles in POC?

Any other idea?