### PR TITLE
Fix bounding sphere computation and use optimized approach

### DIFF
--- a/forge/lib/bounding_sphere.py
+++ b/forge/lib/bounding_sphere.py
@@ -1,94 +1,130 @@
 # -*- coding: utf-8 -*-
 
 import math
-from decimal import Decimal
 
 
 class BoundingSphere(object):
 
     def __init__(self, *args, **kwargs):
-        minVal = Decimal('-Infinity')
-        maxVal = Decimal('Infinity')
-
+        MAX = float('infinity')
+        MIN = float('-infinity')
         self.center = map(float, kwargs.get('center', []))
         self.radius = float(kwargs.get('radius', 0))
-        self.minPoint = [maxVal, maxVal, maxVal]
-        self.maxPoint = [minVal, minVal, minVal]
+        self.minPointX = [MAX, MAX, MAX]
+        self.minPointY = [MAX, MAX, MAX]
+        self.minPointZ = [MAX, MAX, MAX]
+        self.maxPointX = [MIN, MIN, MIN]
+        self.maxPointY = [MIN, MIN, MIN]
+        self.maxPointZ = [MIN, MIN, MIN]
 
     # Based on Ritter's algorithm
     def fromPoints(self, points):
 
-        assert len(points) > 1, 'Your list of points must contain at least 2 points'
-        randomPoint = points[0]
+        if len(points) < 1:
+            raise Exception('Your list of points must contain at least 2 points')
 
-        # Find the point which has the largest distance from the initial random point.
-        a = self.furthestPoint(randomPoint, points)
-        # Search a point b in P, which has the largest distance from a.
-        b = self.furthestPoint(a, points)
-
-        # Initial center and radius (Ritter)
-        self.center = self.getMidPoint(a, b)
-        self.radius = self.distance(a, b)
-
-        # Initial center and radius (naive)
-        naiveCenter = self.getMidPoint(self.minPoint, self.maxPoint)
-        naiveRadius = 0.0
-
-        # Construct a new ball covering both point p and the previous ball
-        for i in range(0, len(points)):
+        nbPositions = len(points)
+        for i in xrange(0, nbPositions):
             point = points[i]
-            distance = self.distance(self.center, point)
-            # Point not included in the sphere
-            if distance > self.radius:
-                self.radius = newRadius = (self.radius + distance) / 2.0
-                oldToNew = distance - newRadius
-                self.center = [
-                    (newRadius * self.center[0] + oldToNew * point[0]) / distance,
-                    (newRadius * self.center[1] + oldToNew * point[1]) / distance,
-                    (newRadius * self.center[2] + oldToNew * point[2]) / distance
-                ]
-            # Naive
-            naiveDistance = self.distance(naiveCenter, point)
-            if naiveDistance > naiveRadius:
-                naiveRadius = naiveDistance
-
-        # Keep the naive sphere if smaller
-        if naiveRadius < self.radius:
-            self.radius = naiveRadius
-            self.center = naiveCenter
-
-    def getMidPoint(self, a, b):
-        return [(a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0, (a[2] + b[2]) / 2.0]
-
-    def furthestPoint(self, pointA, points):
-        maxDistance = 0.0
-
-        for i in range(0, len(points)):
-            point = points[i]
-            distance = self.distance(point, pointA)
-            if maxDistance < distance:
-                maxDistance = distance
-                furthestPoint = point
 
             # Store the points containing the smallest and largest component
             # Used for the naive approach
-            if point[0] < self.minPoint[0]:
-                self.minPoint[0] = point[0]
-            if point[1] < self.minPoint[1]:
-                self.minPoint[1] = point[1]
-            if point[2] < self.minPoint[2]:
-                self.minPoint[2] = point[2]
-            if point[0] > self.maxPoint[0]:
-                self.maxPoint[0] = point[0]
-            if point[1] > self.maxPoint[1]:
-                self.maxPoint[1] = point[1]
-            if point[2] > self.maxPoint[2]:
-                self.maxPoint[2] = point[2]
+            if point[0] < self.minPointX[0]:
+                self.minPointX = point
 
-        return furthestPoint
+            if point[1] < self.minPointY[1]:
+                self.minPointY = point
+
+            if point[2] < self.minPointZ[2]:
+                self.minPointZ = point
+
+            if point[0] > self.maxPointX[0]:
+                self.maxPointX = point
+
+            if point[1] > self.maxPointY[1]:
+                self.maxPointY = point
+
+            if point[2] > self.maxPointZ[2]:
+                self.maxPointZ = point
+
+        # Squared distance between each component min and max
+        xSpan = self.magnitudeSquared(self.subtract(self.maxPointX, self.minPointX))
+        ySpan = self.magnitudeSquared(self.subtract(self.maxPointY, self.minPointY))
+        zSpan = self.magnitudeSquared(self.subtract(self.maxPointZ, self.minPointZ))
+
+        diameter1 = self.minPointX
+        diameter2 = self.maxPointX
+        maxSpan = xSpan
+        if ySpan > maxSpan:
+            maxSpan = ySpan
+            diameter1 = self.minPointY
+            diameter2 = self.maxPointY
+        if zSpan > maxSpan:
+            maxSpan = zSpan
+            diameter1 = self.minPointZ
+            diameter2 = self.maxPointZ
+
+        ritterCenter = [
+            (diameter1[0] + diameter2[0]) * 0.5,
+            (diameter1[1] + diameter2[1]) * 0.5,
+            (diameter1[2] + diameter2[2]) * 0.5
+        ]
+
+        radiusSquared = self.magnitudeSquared(self.subtract(diameter2, ritterCenter))
+        ritterRadius = math.sqrt(radiusSquared)
+
+        # Initial center and radius (naive) get min and max box
+        minBoxPt = [self.minPointX[0], self.minPointY[1], self.minPointZ[2]]
+        maxBoxPt = [self.maxPointX[0], self.maxPointY[1], self.maxPointZ[2]]
+        naiveCenter = self.multiplyByScalar(self.add(minBoxPt, maxBoxPt), 0.5)
+        naiveRadius = 0.0
+
+        for i in xrange(0, nbPositions):
+            currentP = points[i]
+
+            # Find the furthest point from the naive center to calculate the naive radius.
+            r = self.magnitude(self.subtract(currentP, naiveCenter))
+            if r > naiveRadius:
+                naiveRadius = r
+
+            # Make adjustments to the Ritter Sphere to include all points.
+            oldCenterToPointSquared = self.magnitudeSquared(self.subtract(currentP, ritterCenter))
+            if oldCenterToPointSquared > radiusSquared:
+                oldCenterToPoint = math.sqrt(oldCenterToPointSquared)
+                ritterRadius = (ritterRadius + oldCenterToPoint) * 0.5
+                # Calculate center of new Ritter sphere
+                oldToNew = oldCenterToPoint - ritterRadius
+                ritterCenter = [
+                    (ritterRadius * ritterCenter[0] + oldToNew * currentP[0]) / oldCenterToPoint,
+                    (ritterRadius * ritterCenter[1] + oldToNew * currentP[1]) / oldCenterToPoint,
+                    (ritterRadius * ritterCenter[2] + oldToNew * currentP[2]) / oldCenterToPoint,
+                ]
+
+        # Keep the naive sphere if smaller
+        if naiveRadius < ritterRadius:
+            self.radius = ritterRadius
+            self.center = ritterCenter
+        else:
+            self.radius = naiveRadius
+            self.center = naiveCenter
+
+    def magnitudeSquared(self, p):
+        return p[0] ** 2 + p[1] ** 2 + p[2] ** 2
+
+    def magnitude(self, p):
+        return math.sqrt(self.magnitudeSquared(p))
+
+    def add(self, left, right):
+        return [left[0] + right[0], left[1] + right[1], left[2] + right[2]]
+
+    def subtract(self, left, right):
+        return [left[0] - right[0], left[1] - right[1], left[2] - right[2]]
 
     def distanceSquared(self, p1, p2):
-        return math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2 + (p1[2] - p2[2]) ** 2)
+        return (p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2 + (p1[2] - p2[2]) ** 2
 
     def distance(self, p1, p2):
         return math.sqrt(self.distanceSquared(p1, p2))
+
+    def multiplyByScalar(self, p, scalar):
+        return [p[0] * scalar, p[1] * scalar, p[2] * scalar]


### PR DESCRIPTION
This PR optimises the Bounding sphere computation and fixes a bug in the squared distance function.

+ After fixing only the bug on distancesquared function I get:
('boundingSphereCenterX', 4373336.901814363), ('boundingSphereCenterY', 600126
.7298311971), ('boundingSphereCenterZ', 4589252.3353060335), ('boundingSphereRadius', 439.25433669061647)


+ After optimization:
('boundingSphereCenterX', 4373336.901814363), ('boundingSphereCenterY', 600126
.7298311971), ('boundingSphereCenterZ', 4589252.3353060335), ('boundingSphereRadius', 439.25433669061647)

So exactly the same which is good and makes me think it's all good.