### PR TITLE
New testapp and apache config (proxied tiles with various backends)

### DIFF
--- a/apache/testapp.conf.mako
+++ b/apache/testapp.conf.mako
@@ -5,4 +5,15 @@ AliasMatch ^/${user}/3dtest(.*)$ ${directory}/3d-testapp/$1
     Allow from all
 </Directory>
 
+ProxyPassMatch ^/${user}/tiles/([0-9]*)/(.*)$ http://localhost:9014/tiles/$1/$2
+<Proxy http://localhost:9014>
+    Order deny,alloW
+    Allow from all
+</Proxy>
+
+ProxyPassMatch ^/${user}/tiles/(.*)$ http://ec2-54-220-242-89.eu-west-1.compute.amazonaws.com/stk-terrain/tilesets/swisseudem/tiles/$1
+<Proxy http://ec2-54-220-242-89.eu-west-1.compute.amazonaws.com>
+    Order deny,allow
+    Allow from all
+</Proxy>
 


### PR DESCRIPTION
For this to work, you need https://github.com/gjn/tileproxy running in the background (in localhost). It's a proxy that will load old tiles (from c2c poc), but for a given range (configured in the tileproxy), will serve new tiles from our own backend.