### PR TITLE
Handle case where the tile is flat

### DIFF
--- a/forge/lib/loaders.py
+++ b/forge/lib/loaders.py
@@ -26,7 +26,7 @@ class ShpToGDALFeatures(object):
         features = [feature for feature in layer]
         if len(features) == 0:
             return features
-            #raise Exception('Empty shapefile')
+            # raise Exception('Empty shapefile')
 
         geometryType = features[0].GetGeometryRef().GetGeometryName()
         if geometryType != 'POLYGON':

--- a/forge/lib/tiler.py
+++ b/forge/lib/tiler.py
@@ -81,7 +81,6 @@ class GlobalGeodeticTiler:
             else:
                 print 'Skipping %s because no features have been found for this tile' % bucketKey
 
-
     def _splitAndRemoveNonTriangles(self, features):
         rings = []
         for feature in features:

--- a/forge/models/terrain.py
+++ b/forge/models/terrain.py
@@ -412,10 +412,17 @@ class TerrainTile:
 
         bLon = MAX / (self._east - self._west)
         bLat = MAX / (self._north - self._south)
-        bHeight = MAX / (self.header['maximumHeight'] - self.header['minimumHeight'])
+
         quantizeLonIndices = lambda x: int(round((x - self._west) * bLon))
         quantizeLatIndices = lambda x: int(round((x - self._south) * bLat))
-        quantizeHeightIndices = lambda x: int(round((x - self.header['minimumHeight']) * bHeight))
+
+        deniv = self.header['maximumHeight'] - self.header['minimumHeight']
+        # In case a tile is completely flat
+        if deniv == 0:
+            quantizeHeightIndices = lambda x: 0
+        else:
+            bHeight = MAX / deniv
+            quantizeHeightIndices = lambda x: int(round((x - self.header['minimumHeight']) * bHeight))
 
         # High watermark encoding performed during toFile
         self.u = map(quantizeLonIndices, topology.uVertex)


### PR DESCRIPTION
When minHeight and maxHeight are identical a zero float division error is raised.

This should not happen very often but it is possible.

As all the height values are identical and are supposed to be within a range of quantized values ([0, 32767]) we can simply populate the height list with zeroes.
