### PR TITLE
Add possibility to duplicate complete set of tiles from POC to tms bu…

### DIFF
--- a/forge/lib/tiler.py
+++ b/forge/lib/tiler.py
@@ -48,6 +48,7 @@ def worker(job):
     session = None
     pid = os.getpid()
     retval = 0
+    tstart = time.time()
 
     try:
         (config, tileMinZ, tileMaxZ, bounds, tileXYZ, t0, bucket) = job
@@ -103,12 +104,11 @@ def worker(job):
             # logger.info('[%s] It took %s to create %s tile on S3.' % (pid, str(tend-tstart), bucketKey))
             tilecount.value += 1
             count += 1
-            if count == 1:
-                logger.info('[%s] It took %s to create %s tiles on S3.' % (pid, str(datetime.timedelta(seconds=tend - t0)), count))
+            logger.info('[%s] It took %s to create %s tile on S3. (%s total in this process)' % (pid, str(datetime.timedelta(seconds=tend - tstart)), bucketKey, count))
 
-            # val = tilecount.value
-            #  if val % 100 == 0:
-            #     logger.info('[%s] It took %s to create %s tiles on S3.' % (pid, str(datetime.timedelta(seconds=tend-t0)), val))
+            val = tilecount.value
+            if val % 10 == 0:
+                logger.info('[%s] It took %s to create %s tiles on S3.' % (pid, str(datetime.timedelta(seconds=tend-t0)), val))
 
         else:
             # One should write an empyt tile

--- a/forge/scripts/poctiles2tmstiles.py
+++ b/forge/scripts/poctiles2tmstiles.py
@@ -3,6 +3,8 @@
 import sys
 import gzip
 import os
+import getopt
+import json
 from urllib2 import urlopen
 from textwrap import dedent
 
@@ -25,88 +27,126 @@ tms_from_shape_file_name = "tmp/tms.from.shape.terrain"
 
 def usage():
     print(dedent('''\
-        Usage: venv/bin/python forge/script/poctiles2tmstiles.py <file>')
+        Usage: venv/bin/python forge/script/poctiles2tmstiles.py [-f <nr>|--from=<nr>] [-t <nr>|--to=<nr>] [<file>]')
+
+        - f (from zoom level, as read from top-level layers.json
+        - t (to zoom level, as read from top-level layers.json
 
         The <file> contains tiles to transform in the form /z/x/y
-
-        Could/should be adapted to define range easier, and not via file.
+        
+        <file> and -f/-t are mutually exclusive (can't have both at same time)
 
         Script will
             1) get given tile from poc url
             2) read tile with TerrainTile class (fromFile function)
-            3) write tile to shapefile
-            4) Create tile from shapefile
-            4) Write tile to our S3 bucket under given addres /z/x/y
+            3) Write tile to our S3 bucket under given addres /z/x/y
     '''))
 
 
 def main():
-    if len(sys.argv) != 2:
-        error("Please specify a file.", 4, usage=usage)
-    ffile = sys.argv[1]
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'f:t:', ['from=', 'to='])
+    except getopt.GetoptError as err:
+        error(str(err), 2, usage=usage)
+
+    ffrom = None
+    to = None
+    ffile = None
+
+    for o, a in opts:
+        if o in ('-f', '--from'):
+            ffrom = a
+        if o in ('-t', '--to'):
+            to = a
+
+    if ffrom is None or to is None:
+        if len(args) != 1:
+            error("Please specify a file.", 4, usage=usage)
+        ffile = args[0]
+    
+    tiles = []
+
+    # We have file, so we get the tiles from the file
+    if ffile is not None:
+        with open(ffile) as f:
+            for line in f:
+                line = line.rstrip()
+                if len(line) > 2:
+                    tiles.append(map(int, line.split('/')))
+
+    # If we have from to, we catch layers.json from poc and use from to for levels
+    if ffrom is not None and to is not None:
+        req = urlopen(poc_base_url + 'layer.json')
+        layers = {}
+        for line in req:
+            layers = json.loads(line)
+        for zoom in range(int(ffrom), int(to) + 1):
+            level = layers['available'][zoom][0]
+            for x in range(int(level['startX']), int(level['endX']) + 1):
+                for y in range(int(level['startY']), int(level['endY']) + 1):
+                    tiles.append([zoom, x, y])
+
     bucket = getBucket()
     g = GlobalGeodetic(tmscompatible=True)
     if not os.path.isdir('tmp'):
         os.mkdir('tmp')
-    with open(ffile) as f:
-        for line in f:
-            line = line.rstrip()
-            if len(line) > 2:
-                req = None
-                # Getting Tilebounds with GlobalGeodetic
-                splits = map(int, line.split('/'))
-                tilebounds = g.TileBounds(splits[1], splits[2], splits[0])
-                try:
-                    url = poc_base_url + line + ".terrain?v=2.0.0"
-                    req = urlopen(url)
-                    with open(gzip_file_name, 'wb') as fp:
-                        fp.write(req.read())
-                    ff = gzip.open(gzip_file_name)
-                    with open(temp_file_name, 'wb') as fp:
-                        fp.write(ff.read())
+    for tile in tiles:
+        req = None
+        tilebounds = g.TileBounds(tile[1], tile[2], tile[0])
+        tilestring = str(tile[0]) + "/" + str(tile[1]) + "/" +  str(tile[2])
+        try:
+            url = poc_base_url + tilestring + ".terrain?v=2.0.0"
+            req = urlopen(url)
+            with open(gzip_file_name, 'wb') as fp:
+                fp.write(req.read())
+            ff = gzip.open(gzip_file_name)
+            with open(temp_file_name, 'wb') as fp:
+                fp.write(ff.read())
 
-                    ter = TerrainTile()
-                    ter.fromFile(temp_file_name, tilebounds[0], tilebounds[2], tilebounds[1], tilebounds[3])
+            ter = TerrainTile()
+            ter.fromFile(temp_file_name, tilebounds[0], tilebounds[2], tilebounds[1], tilebounds[3])
+            '''
+            if os.path.isfile(tms_file_name):
+                os.remove(tms_file_name)
 
-                    if os.path.isfile(tms_file_name):
-                        os.remove(tms_file_name)
+            if os.path.isfile(shape_file_name):
+                os.remove(shape_file_name)
 
-                    if os.path.isfile(shape_file_name):
-                        os.remove(shape_file_name)
+            if os.path.isfile(tms_from_shape_file_name):
+                os.remove(tms_from_shape_file_name)
 
-                    if os.path.isfile(tms_from_shape_file_name):
-                        os.remove(tms_from_shape_file_name)
+            ter.toFile(tms_file_name)
+            ter.toShapefile(shape_file_name)
 
-                    ter.toFile(tms_file_name)
-                    ter.toShapefile(shape_file_name)
+            shapefile = ShpToGDALFeatures(shpFilePath=shape_file_name)
+            features = shapefile.__read__()
+            topology = TerrainTopology(features=features)
+            topology.fromFeatures()
 
-                    shapefile = ShpToGDALFeatures(shpFilePath=shape_file_name)
-                    features = shapefile.__read__()
-                    topology = TerrainTopology(features=features)
-                    topology.fromFeatures()
+            terFromPoc = TerrainTile()
+            terFromPoc.fromFile(tms_file_name, tilebounds[0], tilebounds[2], tilebounds[1], tilebounds[3])
 
-                    terFromPoc = TerrainTile()
-                    terFromPoc.fromFile(tms_file_name, tilebounds[0], tilebounds[2], tilebounds[1], tilebounds[3])
+            terFromShape = TerrainTile()
+            terFromShape.fromTerrainTopology(topology)
+            terFromShape.toFile(tms_from_shape_file_name)
 
-                    terFromShape = TerrainTile()
-                    terFromShape.fromTerrainTopology(topology)
-                    terFromShape.toFile(tms_from_shape_file_name)
+            # Use this to select what is written to s3
+            ter2 = terFromShape
+            '''
+            ter2 = ter
 
-                    # Use this to select what is written to s3
-                    ter2 = terFromShape
+            fileObject = ter2.toStringIO()
+            compressedFile = gzipFileObject(fileObject)
 
-                    fileObject = ter2.toStringIO()
-                    compressedFile = gzipFileObject(fileObject)
+            bucketKey = tilestring + '.terrain'
+            print 'Uploading %s to S3' % bucketKey
+            writeToS3(bucket, bucketKey, compressedFile)
 
-                    bucketKey = line + '.terrain'
-                    print 'Uploading %s to S3' % bucketKey
-                    writeToS3(bucket, bucketKey, compressedFile)
-
-                except Exception as e:
-                    print "error with " + line + " " + str(e)
-                finally:
-                    if req:
-                        req.close()
+        except Exception as e:
+            print "error with " + line + " " + str(e)
+        finally:
+            if req:
+                req.close()
     return 0
 
 


### PR DESCRIPTION
This extend the poc script to allow the full duplication of POC tiles into our tms tiles. I've already run it (see usage output of command).

Now, we have levels 0 to 8 fully in our tms bucket (and they are exact copies of the POC).

This should allow us to get rid of our proxies to mix tiles from POC and tms.