### PR TITLE
Remove proxy to poc tiles

### DIFF
--- a/apache/testapp.conf.mako
+++ b/apache/testapp.conf.mako
@@ -4,14 +4,3 @@ AliasMatch ^/${user}/3dtest(.*)$ ${directory}/3d-testapp/$1
     Order allow,deny
     Allow from all
 </Directory>
-
-RewriteRule ^/${user}/tiles/([0-7]?)/(.*)$ http://ec2-54-220-242-89.eu-west-1.compute.amazonaws.com/stk-terrain/tilesets/swisseudem/tiles/$1/$2 [L,P,QSA]
-
-RewriteRule ^/${user}/tiles/(8|9|[0-9]{2})/(.*) http://tms3d.geo.admin.ch.s3.amazonaws.com/$1/$2 [L,P,QSA]
-
-RewriteRule ^/${user}/tiles/(.*)$ http://ec2-54-220-242-89.eu-west-1.compute.amazonaws.com/stk-terrain/tilesets/swisseudem/tiles/$1 [P,QSA]
-
-<Location /${user}/tiles>
-  Order deny,allow
-  Allow from all
-</Location>


### PR DESCRIPTION
This removes the apache configuration that enables dual access to tile (poc and tms). Now that we can visaulize any generated tiles, we should use those in tms only.

(note: level 0 to 8 contain the POC tiles in our tms bucket)