### PR TITLE
Use min distance as a collapsing criterion

### DIFF
--- a/forge/lib/collapse_geom.py
+++ b/forge/lib/collapse_geom.py
@@ -50,7 +50,7 @@ def collapseIntoTriangles(ring):
         coordsPairs = createCoordsPairs(coords)
         sDistances = squaredDistances(coordsPairs)
 
-        index = sDistances.index(max(sDistances))
+        index = sDistances.index(min(sDistances))
         i = getCoordsIndex(len(coords), index)
         triangle = coordsPairs[index] + [coords[i]]
         triangles.append(triangle)


### PR DESCRIPTION
This is a better approximation to collapse the triangles. (We want to avoid skinny triangles)

The perfect solution would be to perform a Delaunay triangulation, but we'd need scipy for that which we don't have at the moment and can't install until tileforge instance is update with python-scipy.
