### PR TITLE
Write origin of tile into metadata of generated tile on S3

### DIFF
--- a/forge/lib/boto_conn.py
+++ b/forge/lib/boto_conn.py
@@ -23,9 +23,10 @@ def getBucket(bucketName='tms3d.geo.admin.ch'):
     return bucket
 
 
-def writeToS3(b, path, content, contentType='application/octet-stream'):
+def writeToS3(b, path, content, origin, contentType='application/octet-stream'):
     headers = {'Content-Type': contentType}
     k = Key(b)
     k.key = path
+    k.set_metadata('IWI_Origin', origin)
     headers['Content-Encoding'] = 'gzip'
     k.set_contents_from_file(content, headers=headers)

--- a/forge/lib/tiler.py
+++ b/forge/lib/tiler.py
@@ -100,7 +100,7 @@ def worker(job):
             fileObject = terrainFormat.toStringIO()
             compressedFile = gzipFileObject(fileObject)
 
-            writeToS3(bucket, bucketKey, compressedFile)
+            writeToS3(bucket, bucketKey, compressedFile, model.__tablename__)
             tend = time.time()
             tilecount.value += 1
             count += 1

--- a/forge/scripts/poctiles2tmstiles.py
+++ b/forge/scripts/poctiles2tmstiles.py
@@ -140,7 +140,7 @@ def main():
 
             bucketKey = tilestring + '.terrain'
             print 'Uploading %s to S3' % bucketKey
-            writeToS3(bucket, bucketKey, compressedFile)
+            writeToS3(bucket, bucketKey, compressedFile, 'POC Tiles copy')
 
         except Exception as e:
             print "error with " + line + " " + str(e)

--- a/forge/scripts/tiles_writer.py
+++ b/forge/scripts/tiles_writer.py
@@ -36,7 +36,7 @@ for f in shapefilesNames:
     # for now
     keyPath = f[1:3] + '/' + f[3:9] + '/' + f[9:14] + extension
     print 'Writing %s to S3' % keyPath
-    writeToS3(bucket, keyPath, compressedFile)
+    writeToS3(bucket, keyPath, compressedFile, basePath)
     i += 1
     t1 = time.time()
     ti = t1 - t0


### PR DESCRIPTION
This write `x-amz-meta-iwi_origin: origin` header to the S3 object in the bucket. The origin, when run with standard tiler, is the table in postgres. e.g `x-amz-meta-iwi_origin: break_lines_1m`

@procrastinatio Quick review/merge?