### PR TITLE
Only fully intersectable tiles possible

### DIFF
--- a/forge/lib/tiler.py
+++ b/forge/lib/tiler.py
@@ -28,10 +28,12 @@ config = ConfigParser.RawConfigParser()
 config.read('database.cfg')
 logger = getLogger(config, __name__, suffix=timestamp())
 
+
 def is_inside(tile, bounds):
     if tile[0] >= bounds[0] and tile[1] >= bounds[1] and tile[2] <= bounds[2] and tile[3] >= bounds[3]:
         return True
     return False
+
 
 def grid(bounds, zoomLevels, fullonly):
     geodetic = GlobalGeodetic(True)
@@ -224,7 +226,7 @@ class TilerManager:
             nbObjects = self.DBSession.query(model).filter(model.bboxIntersects(bounds)).count()
             tileMinX, tileMinY = geodetic.LonLatToTile(bounds[0], bounds[1], zoom)
             tileMaxX, tileMaxY = geodetic.LonLatToTile(bounds[2], bounds[3], zoom)
-            # Fast approach, but might not be fully correct 
+            # Fast approach, but might not be fully correct
             if self.fullonly == 1:
                 tileMinX += 1
                 tileMinY += 1

--- a/tms.cfg
+++ b/tms.cfg
@@ -6,6 +6,9 @@ minLon: 5.74569
 maxLon: 10.60591
 minLat: 45.83312
 maxLat: 47.74443
+# fullonly: 0 -> inludes all tiles that intersect, even partly, with extent
+# fullonly: 1 -> include only tiles that fully intersect with extent
+fullonly: 1
 
 [Zooms]
 tileMinZ: 9
@@ -37,3 +40,4 @@ tablename: break_lines_1m
 
 [17]
 tablename: break_lines_0_5m
+


### PR DESCRIPTION
This PR adds a new parameter to tiles generation. Currently, the extent specifies is applied loosely and tiles are generated that intersect with the given extent. Even tiles only have 1 single corner in the extent will be done. This might be good for most use cases.

With the new parameter (fullonly), you can generate only tiles that are fully within the given extent.

Note thats stats generated with fullonly=1 are not 100% accurate but a (fast) estimate.