### PR TITLE
Add basic stats from bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VENV = venv
 PYTHON_CMD = $(VENV)/bin/python
 PORT ?= 9025
+PREFIX ?= 1/
 PYTHON_FILES := $(shell find forge/ -name '*.py')
 USERNAME := $(shell whoami)
 
@@ -16,10 +17,13 @@ help:
 	@echo "- all                All of the above"
 	@echo "- autolint           Auto lint code styling"
 	@echo "- updatesubmodule    Update 3d testapp"
-	@echo "- serve              Serve examples in localhost (usage make serve PORT=9005)"
+	@echo "- serve              Serve examples in localhost (usage: make serve PORT=9005)"
 	@echo "- createdb           Create the database"
 	@echo "- importshp          Imports shapefiles"
 	@echo "- dropdb             Drop the database"
+	@echo "- counttiles         Count tiles in S3 bucket using a prexfix (usage: make counttiles PREFIX=12/)"
+	@echo "- deletetiles        Delete tiles in S3 bucket using a prefix (usage: make deletetiles PREFIX=12/)"
+	@echo "- listtiles          List tiles in S3 bucket using a prefix (usage: make listtiles PREFIX=12/)"
 	@echo "- tmspyramid         Create the TMS pyramid based on the config file tms.cfg"
 	@echo "- tmsstats           Provide statistics about the TMS pyramid"
 	@echo "- clean              Clean all generated files and folders"
@@ -78,6 +82,18 @@ importshp:
 .PHONY: dropdb
 dropdb:
 	$(PYTHON_CMD) forge/scripts/db_management.py destroy
+
+.PHONY: counttiles
+counttiles:
+	$(PYTHON_CMD) forge/scripts/s3_tiles.py -p $(PREFIX) count
+
+.PHONY: deletetiles
+deletetiles:
+	$(PYTHON_CMD) forge/scripts/s3_tiles.py -p $(PREFIX) delete
+
+.PHONY: listtiles
+listtiles:
+	$(PYTHON_CMD) forge/scripts/s3_tiles.py -p $(PREFIX) list
 
 .PHONY: tmspyramid
 tmspyramid:

--- a/forge/lib/boto_conn.py
+++ b/forge/lib/boto_conn.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import sys
 import time
 import logging
 from boto import connect_s3
@@ -49,6 +50,10 @@ class S3Keys:
     def delete(self):
         count = 0
         keysToDelete = []
+        print 'Are you sure you want to delete all tiles starting with %s? (y/n)' % self.prefix
+        answer = raw_input('> ')
+        if answer.lower() != 'y':
+            sys.exit(1)
         print 'Deleting keys for prefix %s...' % self.prefix
         for key in self.keysList:
             keysToDelete.append(key)

--- a/forge/lib/boto_conn.py
+++ b/forge/lib/boto_conn.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import time
+import logging
 from boto import connect_s3
 from boto.s3.key import Key
+
+logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 
 def _getS3Conn(profileName='tms3d_filestorage'):
@@ -30,3 +34,46 @@ def writeToS3(b, path, content, origin, contentType='application/octet-stream'):
     k.set_metadata('IWI_Origin', origin)
     headers['Content-Encoding'] = 'gzip'
     k.set_contents_from_file(content, headers=headers)
+
+
+class S3Keys:
+
+    def __init__(self, prefix):
+        self.bucket = getBucket()
+        if prefix is not None:
+            self.prefix = prefix
+        else:
+            raise Exception('One must define a prefix')
+        self.keysList = self.bucket.list(prefix=self.prefix)
+
+    def delete(self):
+        count = 0
+        keysToDelete = []
+        print 'Deleting keys for prefix %s...' % self.prefix
+        for key in self.keysList:
+            keysToDelete.append(key)
+            count += 1
+            if len(keysToDelete) % 1000 == 0:
+                temp = self.bucket.delete_keys(keysToDelete)
+                print '%s could not be deleted.' % len(temp.errors)
+                print '%s have been deleted.' % len(temp.deleted)
+                keysToDelete = []
+        if len(keysToDelete) > 0:
+            self.bucket.delete_keys(keysToDelete)
+        print '%s keys have been deleted' % count
+
+    def listKeys(self):
+        print 'Listing keys for prefix %s...' % self.prefix
+        for key in self.keysList:
+            print "{name}\t{size}\t{modified}".format(
+                name=key.name,
+                size=key.size,
+                modified=key.last_modified,
+            )
+            # So that one can interrput it from keyboard
+            time.sleep(.2)
+
+    def count(self):
+        print 'Counting keys for prefix %s...' % self.prefix
+        nbKeys = len(list(self.keysList))
+        print '%s keys have been found for prefix %s' % (nbKeys, self.prefix)

--- a/forge/lib/boto_conn.py
+++ b/forge/lib/boto_conn.py
@@ -41,6 +41,7 @@ class S3Keys:
 
     def __init__(self, prefix):
         self.bucket = getBucket()
+        self.counter = 0
         if prefix is not None:
             self.prefix = prefix
         else:
@@ -48,7 +49,6 @@ class S3Keys:
         self.keysList = self.bucket.list(prefix=self.prefix)
 
     def delete(self):
-        count = 0
         keysToDelete = []
         print 'Are you sure you want to delete all tiles starting with %s? (y/n)' % self.prefix
         answer = raw_input('> ')
@@ -57,15 +57,12 @@ class S3Keys:
         print 'Deleting keys for prefix %s...' % self.prefix
         for key in self.keysList:
             keysToDelete.append(key)
-            count += 1
             if len(keysToDelete) % 1000 == 0:
-                temp = self.bucket.delete_keys(keysToDelete)
-                print '%s could not be deleted.' % len(temp.errors)
-                print '%s have been deleted.' % len(temp.deleted)
+                self._deleteKeysResults(self.bucket.delete_keys(keysToDelete))
                 keysToDelete = []
         if len(keysToDelete) > 0:
-            self.bucket.delete_keys(keysToDelete)
-        print '%s keys have been deleted' % count
+            self._deleteKeysResults(self.bucket.delete_keys(keysToDelete))
+        print '%s keys have been deleted' % self.counter
 
     def listKeys(self):
         print 'Listing keys for prefix %s...' % self.prefix
@@ -82,3 +79,9 @@ class S3Keys:
         print 'Counting keys for prefix %s...' % self.prefix
         nbKeys = len(list(self.keysList))
         print '%s keys have been found for prefix %s' % (nbKeys, self.prefix)
+
+    def _deleteKeysResults(self, results):
+        nbDeleted = len(results.deleted)
+        print '%s could not be deleted.' % len(results.errors)
+        print '%s have been deleted.' % nbDeleted
+        self.counter += len(results.deleted)

--- a/forge/lib/topology.py
+++ b/forge/lib/topology.py
@@ -108,7 +108,7 @@ class TerrainTopology(object):
         ring = self._assureRingCounterClockWise(ring)
 
         for coord in ring:
-            lookupKey= ','.join([str(coord[0]), str(coord[1]), str(coord[2])])
+            lookupKey = ','.join([str(coord[0]), str(coord[1]), str(coord[2])])
             indexData = self._findVertexIndex(lookupKey)
             if indexData is not None:
                 self.indexData.append(indexData)

--- a/forge/scripts/s3_tiles.py
+++ b/forge/scripts/s3_tiles.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import getopt
+from textwrap import dedent
+from forge.lib.helpers import error
+from forge.lib.boto_conn import S3Keys
+
+
+# One might want to provide an extent also later on
+def usage():
+    print(dedent('''\
+        Usage: venv/bin/python forge/script/s3_tiles.py [-p <prefix>|--prefix=<prefix>] <command>')
+
+        Commands:
+            delete:             delete all keys (tiles)
+            list:               list all keys (tiles)
+            count:              count all keys (tiles)
+    '''))
+
+
+def main():
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'p:', ['p='])
+    except getopt.GetoptError as err:
+        error(str(err), 2, usage=usage)
+
+    prefix = None
+    for o, a in opts:
+        if o in ('-p', '--prefix'):
+            prefix = a
+
+    if len(args) < 1:
+        error('you must specify a command', 3, usage=usage)
+
+    s3Keys = S3Keys(prefix)
+
+    command = args[0]
+    if command == 'delete':
+        s3Keys.delete()
+    elif command == 'list':
+        s3Keys.listKeys()
+    elif command == 'count':
+        s3Keys.count()
+    else:
+        error("unknown command '%(command)s'" % {'command': command}, 4, usage=usage)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Here is an example of command:

venv/bin/python forge/scripts/s3_tiles.py -p 2/ count

32 keys have been found for prefix 2/


venv/bin/python forge/scripts/s3_tiles.py -p 2/ list

Listing keys for prefix 2/...
2/0/0.terrain   687     2015-07-13T12:19:59.000Z
2/0/1.terrain   877     2015-07-13T12:19:59.000Z
2/0/2.terrain   861     2015-07-13T12:19:59.000Z
2/0/3.terrain   621     2015-07-13T12:19:59.000Z
2/1/0.terrain   635     2015-07-13T12:19:59.000Z
2/1/1.terrain   864     2015-07-13T12:19:59.000Z
2/1/2.terrain   868     2015-07-13T12:19:59.000Z
2/1/3.terrain   612     2015-07-13T12:19:59.000Z

....


venv/bin/python forge/scripts/s3_tiles.py -p 12/ delete

8190 keys have been deleted


Last command does not work because of S3 bucket policy.
It returns errors: 

Error: 12/4339/3133.terrain(AccessDenied)

@danduk82  Can you give us the ability to deleted files in an S3 bucket please?

One can extend this script to provide an extent etc..
