### PR TITLE
Introduce Models manager

### DIFF
--- a/forge/db.py
+++ b/forge/db.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 from forge.lib.logs import getLogger
 from forge.lib.shapefile_utils import ShpToGDALFeatures
 from forge.lib.helpers import BulkInsert, timestamp, cleanup
-from forge.models.tables import Base, models
+from forge.models.tables import Base, modelsPyramid
 
 
 config = ConfigParser.RawConfigParser()
@@ -93,6 +93,7 @@ def populateFeatures(args):
             raise Exception(e)
 
     try:
+        models = modelsPyramid.models
         engine = sqlalchemy.create_engine(args.engineURL)
         session = scoped_session(sessionmaker(bind=engine))
         model = models[args.modelIndex]
@@ -319,6 +320,7 @@ class DB:
 
         reproject = config.get('Reprojection', 'reproject')
         tstart = time.time()
+        models = modelsPyramid.models
         featuresArgs = []
         for i in range(0, len(models)):
             model = models[i]

--- a/forge/lib/collapse_geom.py
+++ b/forge/lib/collapse_geom.py
@@ -26,19 +26,22 @@ def squaredDistances(coordsPairs):
     return sDistances
 
 
+def processRingCoordinates(ringCoordinates):
+    nbPoints = len(ringCoordinates) - 1
+    if nbPoints >= 4:
+        # If this condition is not respected it means that we clipped
+        # geometries that were not triangles
+        if nbPoints not in (4, 5, 6, 7):
+            raise Exception('Error while processing the clipped geometries: %s coords have been found' % nbPoints)
+        return collapseIntoTriangles(ringCoordinates)
+    else:
+        return [ringCoordinates[0: len(ringCoordinates) - 1]]
+
+
 def processRingsCoordinates(ringsCoordinates):
     rings = []
     for ring in ringsCoordinates:
-        nbPoints = len(ring) - 1
-        if nbPoints >= 4:
-            # If this condition is not respected it means that we clipped
-            # geometries that were not triangles
-            if nbPoints not in (4, 5, 6, 7):
-                raise Exception('Error while processing the clipped geometries: %s coords have been found' % nbPoints)
-            triangles = collapseIntoTriangles(ring)
-            rings += triangles
-        else:
-            rings += [ring[0: len(ring) - 1]]
+        rings += processRingCoordinates(ring)
     return rings
 
 

--- a/forge/lib/helpers.py
+++ b/forge/lib/helpers.py
@@ -27,6 +27,15 @@ def zigZagDecode(z):
     # return (z >> 1) if not z & 1 else -(z+1 >> 1)
 
 
+def createBBox(center, length):
+    offset = length / 2
+    xmin = center[0] - offset
+    ymin = center[1] - offset
+    xmax = center[0] + offset
+    ymax = center[1] + offset
+    return [xmin, ymin, xmax, ymax]
+
+
 def transformCoordinate(wkt, srid_from, srid_to):
     srid_in = osr.SpatialReference()
     srid_in.ImportFromEPSG(srid_from)

--- a/forge/lib/tiler.py
+++ b/forge/lib/tiler.py
@@ -70,7 +70,7 @@ def worker(job):
     pid = os.getpid()
 
     try:
-        (tmsConfig, tileMinZ, tileMaxZ, bounds, tileXYZ, t0, bucket) = job
+        (bounds, tileXYZ, t0, bucket) = job
         # Prepare models
         db = DB('database.cfg')
         session = sessionmaker()(bind=db.userEngine)
@@ -189,7 +189,7 @@ class Jobs:
         bucket = getBucket()
         zRange = range(self.tileMinZ, self.tileMaxZ + 1)
         for bounds, tileXYZ in grid((self.minLon, self.minLat, self.maxLon, self.maxLat), zRange, self.fullonly):
-            yield (self.tmsConfig, self.tileMinZ, self.tileMaxZ, bounds, tileXYZ, self.t0, bucket)
+            yield (bounds, tileXYZ, self.t0, bucket)
 
 
 class Chunks:


### PR DESCRIPTION
In this PR:

- Models manager
- One instead of 4 requests for corners corrections
- Process rings in the same loop

Feuillet où on peut retrouver les artefacts aux frontières des tuiles: 1209-13

I couldn't understand what's wrong yet.

For these 2 tiles I get:

`````
Table name:
break_lines_16m
Bucket key:
12/4277/3111.terrain
Rings length:
5317
Table name:
break_lines_16m
Bucket key:
12/4277/3112.terrain
Rings length:
9952
````

