### PR TITLE
Fully qualified path for our terrain tiles

### DIFF
--- a/forge/lib/boto_conn.py
+++ b/forge/lib/boto_conn.py
@@ -3,10 +3,15 @@
 import sys
 import time
 import logging
+import ConfigParser
 from boto import connect_s3
 from boto.s3.key import Key
 
 logging.getLogger('boto').setLevel(logging.CRITICAL)
+
+tmsConfig = ConfigParser.RawConfigParser()
+tmsConfig.read('tms.cfg')
+basePath = tmsConfig.get('General', 'bucketpath')
 
 
 def _getS3Conn(profileName='tms3d_filestorage'):
@@ -31,7 +36,7 @@ def getBucket(bucketName='tms3d.geo.admin.ch'):
 def writeToS3(b, path, content, origin, contentType='application/octet-stream'):
     headers = {'Content-Type': contentType}
     k = Key(b)
-    k.key = path
+    k.key = basePath + path
     k.set_metadata('IWI_Origin', origin)
     headers['Content-Encoding'] = 'gzip'
     k.set_contents_from_file(content, headers=headers)
@@ -43,7 +48,7 @@ class S3Keys:
         self.bucket = getBucket()
         self.counter = 0
         if prefix is not None:
-            self.prefix = prefix
+            self.prefix = basePath + prefix
         else:
             raise Exception('One must define a prefix')
         self.keysList = self.bucket.list(prefix=self.prefix)

--- a/tms.cfg
+++ b/tms.cfg
@@ -4,6 +4,8 @@
 multiProcessing: 1
 # number of chunks to pass to processing pool
 chunks: 2500
+# terrain files base path
+bucketpath: 1.0.0/ch.swisstopo.terrain.3d/default/20151231/4326/
 
 [Extent]
 minLon: 7.456
@@ -15,8 +17,8 @@ maxLat: 47.119
 fullonly: 1
 
 [Zooms]
-tileMinZ: 18
-tileMaxZ: 18
+tileMinZ: 9
+tileMaxZ: 9
 
 [9]
 tablename: mnt25_simplified_100m


### PR DESCRIPTION
ch.swisstopo.terrain.3d is the official 'layer' name of our terrain tiles. This PR add the URL scheme when writing files to the S3 bucket, using the wmts scheme approach.

A sample URL: http://3d.geo.admin.ch/1.0.0/ch.swisstopo.terrain.3d/default/20151231/4326/9/534/389.terrain

@cedricmoullet @ltclm @cedricmoullet Could you give your official approval of this scheme?
`{version.number}/ch.swisstopo.terrain.3d/{style}/{timestamp}/{epsgcode}/{zoom/lod}/{X}/{Y}.terrain`

Once approved, we should start creating tiles with these scheme. Also, we could do a one time action and transfere all existing tiles to the the folder.