### PR TITLE
Processing managed in poolmanager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 	@echo "- listtiles          List tiles in S3 bucket using a prefix (usage: make listtiles PREFIX=12/)"
 	@echo "- tmspyramid         Create the TMS pyramid based on the config file tms.cfg"
 	@echo "- tmsstats           Provide statistics about the TMS pyramid"
+	@echo "- tmsstatsnodb       Provide statistics about the TMS pyramid, without db stats"
 	@echo "- clean              Clean all generated files and folders"
 	@echo
 	@echo "Variables:"
@@ -102,6 +103,10 @@ tmspyramid:
 .PHONY: tmsstats
 tmsstats:
 	$(PYTHON_CMD) forge/scripts/tms_writer.py stats
+
+.PHONY: tmsstatsnodb
+tmsstatsnodb:
+	$(PYTHON_CMD) forge/scripts/tms_writer.py statsnodb
 
 .PHONY: clean
 clean:

--- a/forge/lib/poolmanager.py
+++ b/forge/lib/poolmanager.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import time
+import multiprocessing
+import signal
+import ConfigParser
+
+from forge.lib.logs import getLogger
+from forge.lib.helpers import timestamp
+
+NUMBER_POOL_PROCESSES = multiprocessing.cpu_count()
+
+dbConfig = ConfigParser.RawConfigParser()
+dbConfig.read('database.cfg')
+logger = getLogger(dbConfig, __name__, suffix=timestamp())
+
+
+# Assure that sub processes don't get keyborad interrupts
+def initProcess():
+    logger.info('Starting process id: %s' % multiprocessing.current_process().pid)
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+class PoolManager:
+
+    def __init__(self):
+        self._pool = multiprocessing.Pool(NUMBER_POOL_PROCESSES, initProcess)
+
+    def _abort(self):
+        self._pool.terminate()
+        self._pool.join()
+
+    def numOfProcesses(self):
+        return NUMBER_POOL_PROCESSES
+
+    # Blocking call
+    def process(self, iterable, func, chunks):
+        self._pool.imap_unordered(func, iterable, chunks)
+        self._pool.close()
+        try:
+            while len([p for p in self._pool._pool if p.is_alive()]) > 0:
+                time.sleep(3)
+        except KeyboardInterrupt:
+            logger.info('Keyboard interupt recieved, terminating workers...')
+            self._abort()
+        except Exception as e:
+            logger.error('Error while processing: %s' % e)
+            self._abort()
+            raise Exception(e)
+        self._pool.join()

--- a/forge/scripts/tms_writer.py
+++ b/forge/scripts/tms_writer.py
@@ -41,6 +41,8 @@ def main():
         tiler.create()
     elif command == 'stats':
         tiler.stats()
+    elif command == 'statsnodb':
+        tiler.statsNoDb()
     else:
         error("unknown command '%(command)s'" % {'command': command}, 4, usage=usage)
 

--- a/tms.cfg
+++ b/tms.cfg
@@ -1,11 +1,8 @@
 [General]
-# multiProcessing: 0 -> no multiprocessing
-# multiProcessing: 1 -> multiprocessing based on the nb of processors
-multiProcessing: 1
-# number of chunks to pass to processing pool
-chunks: 2500
 # terrain files base path
 bucketpath: 1.0.0/ch.swisstopo.terrain.3d/default/20151231/4326/
+# chunks per process (that's a maximum)
+chunks: 50
 
 [Extent]
 minLon: 7.456


### PR DESCRIPTION
I little re-factoring.

* New Poolmanager class
* Remove multiprocessing option in config file (we don't use it anymore)
* Ability to create stats without tapping into db (might be slow for high zoom levels) with `make statsnodb`
