### PR TITLE
Use DHM 25 32m for zoom 11

### DIFF
--- a/database.cfg.mako
+++ b/database.cfg.mako
@@ -13,9 +13,9 @@ password: tileforge
 
 [Data]
 baseDir: /geodata/smb/iwi/3DTerrain/2015/
-shapefiles: DHM25/128/,DHM25/64/,NW/128/,NW/64/,NW/32/,NW/16/,NW/8/,NW/4/,NW/2/,NW/1/,NW/0.5/
-tablenames: dhm25_128m,dhm25_64m,bl_128m,bl_64m,bl_32m,bl_16m,bl_8m,bl_4m,bl_2m,bl_1m,bl_0_5m
-modelnames: dhm25_128m,dhm25_64m,bl_128m,bl_64m,bl_32m,bl_16m,bl_8m,bl_4m,bl_2m,bl_1m,bl_0_5m
+shapefiles: DHM25/128/,DHM25/64/,DHM25/32/,NW/128/,NW/64/,NW/32/,NW/16/,NW/8/,NW/4/,NW/2/,NW/1/,NW/0.5/
+tablenames: dhm25_128m,dhm25_64m,dhm25_32m,bl_128m,bl_64m,bl_32m,bl_16m,bl_8m,bl_4m,bl_2m,bl_1m,bl_0_5m
+modelnames: dhm25_128m,dhm25_64m,dhm25_32m,bl_128m,bl_64m,bl_32m,bl_16m,bl_8m,bl_4m,bl_2m,bl_1m,bl_0_5m
 lakes: /home/geodata/lakes/lakes.shp
 
 # Paths must be absolute!

--- a/tms.cfg.mako
+++ b/tms.cfg.mako
@@ -42,7 +42,7 @@ tablename: dhm25_128m
 tablename: dhm25_64m
 
 [11]
-tablename: bl_128m
+tablename: dhm25_32m
 
 [12]
 tablename: bl_64m


### PR DESCRIPTION
DHM25 32meters has been uploaded and related tiles generated.

For http://terrain2.geo.admin.ch/1.0.0/ch.swisstopo.terrain.3d/default/20151231/4326/11/2135/1556.terrain?v=1.0.0

We went from:
92 Kb
to
28 Kb

AND

For
http://terrain2.geo.admin.ch/1.0.0/ch.swisstopo.terrain.3d/default/20151231/4326/11/2141/1555.terrain?v=1.0.0

From
97 Kb
To
60 Kb